### PR TITLE
Upgrade negotiator ">=0.6.1" to fix security CVE-2016-10539.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Kevin Swiber <kswiber@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "negotiator": "~0.2.7",
+    "negotiator": "^0.6.1",
     "pipeworks": "~1.3.1"
   }
 }


### PR DESCRIPTION
Refer to: https://nvd.nist.gov/vuln/detail/CVE-2016-10539